### PR TITLE
Rename to babel-library-boilerplate.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,4 +1,4 @@
-### [2.1.0](https://github.com/6to5/6to5-library-boilerplate/releases/tag/v2.1.0)
+### [2.1.0](https://github.com/babel/babel-library-boilerplate/releases/tag/v2.1.0)
 
 - You no longer need to specify the individual test files in the browser runner; Browserify bundles it all together
 - You can author your unit tests in ES6 now, as well!
@@ -8,7 +8,7 @@
 - Remove code style rules from JSHint
 - Add `gulp watch` to run headless tests as you make changes to the library and tests
 
-### [2.0.0](https://github.com/6to5/6to5-library-boilerplate/releases/tag/v2.0.0)
+### [2.0.0](https://github.com/babel/babel-library-boilerplate/releases/tag/v2.0.0)
 
 This library is now officially endorsed by 6to5! That's pretty cool, right?
 
@@ -18,20 +18,20 @@ This library is now officially endorsed by 6to5! That's pretty cool, right?
 - **Documentation:** Adds browser compatibility to the FAQ
 - **Documentation:** Adds link to Yeoman generator version of this boilerplate
 
-### [1.1.2](https://github.com/6to5/6to5-library-boilerplate/releases/tag/v1.1.2)
+### [1.1.2](https://github.com/babel/babel-library-boilerplate/releases/tag/v1.1.2)
 
 - **Bugfix:** Removes unnecessary loose mode option when bundling the scripts for the browser with 6to5
 - **Refactor:** Removed unnecessary references to the wrapper file from the gulpfile.
 
-### [1.1.1](https://github.com/6to5/6to5-library-boilerplate/releases/tag/v1.1.1)
+### [1.1.1](https://github.com/babel/babel-library-boilerplate/releases/tag/v1.1.1)
 
 - **Enhancement:** Removes unused devDependencies from `package.json`.
 
-### [1.1.0](https://github.com/6to5/6to5-library-boilerplate/releases/tag/v1.1.0)
+### [1.1.0](https://github.com/babel/babel-library-boilerplate/releases/tag/v1.1.0)
 
 **Enhancement:** No more wrapper file, thanks to [esperanto](https://github.com/esperantojs/esperanto).
 
-### [1.0.0](https://github.com/6to5/6to5-library-boilerplate/releases/tag/v1.0.0)
+### [1.0.0](https://github.com/babel/babel-library-boilerplate/releases/tag/v1.0.0)
 
 - **Feature:** Add [david-dm](https://david-dm.org/) badges to the README
 - **Feature:** Add [Code Climate](https://codeclimate.com)
@@ -42,10 +42,10 @@ This library is now officially endorsed by 6to5! That's pretty cool, right?
 - **Bug fix:** Fix issue where browserify errors would break the stream
 - **Bug fix:** Fix issue where watch would load too soon when running browser tests
 
-### [0.1.0](https://github.com/6to5/6to5-library-boilerplate/releases/tag/v0.1.0)
+### [0.1.0](https://github.com/babel/babel-library-boilerplate/releases/tag/v0.1.0)
 
 Nothing of note.
 
-### [0.0.5](https://github.com/6to5/6to5-library-boilerplate/releases/tag/v0.0.5)
+### [0.0.5](https://github.com/babel/babel-library-boilerplate/releases/tag/v0.0.5)
 
 - **Bugfix**: The 6to5 polyfill is now included in the browser test runner

--- a/README.md
+++ b/README.md
@@ -1,9 +1,9 @@
-# 6to5-library-boilerplate
-[![Travis build status](http://img.shields.io/travis/6to5/6to5-library-boilerplate.svg?style=flat)](https://travis-ci.org/6to5/6to5-library-boilerplate)
-[![Code Climate](https://codeclimate.com/github/6to5/6to5-library-boilerplate/badges/gpa.svg)](https://codeclimate.com/github/6to5/6to5-library-boilerplate)
-[![Test Coverage](https://codeclimate.com/github/6to5/6to5-library-boilerplate/badges/coverage.svg)](https://codeclimate.com/github/6to5/6to5-library-boilerplate)
-[![Dependency Status](https://david-dm.org/6to5/6to5-library-boilerplate.svg)](https://david-dm.org/6to5/6to5-library-boilerplate)
-[![devDependency Status](https://david-dm.org/6to5/6to5-library-boilerplate/dev-status.svg)](https://david-dm.org/6to5/6to5-library-boilerplate#info=devDependencies)
+# babel-library-boilerplate
+[![Travis build status](http://img.shields.io/travis/babel/babel-library-boilerplate.svg?style=flat)](https://travis-ci.org/babel/babel-library-boilerplate)
+[![Code Climate](https://codeclimate.com/github/babel/babel-library-boilerplate/badges/gpa.svg)](https://codeclimate.com/github/babel/babel-library-boilerplate)
+[![Test Coverage](https://codeclimate.com/github/babel/babel-library-boilerplate/badges/coverage.svg)](https://codeclimate.com/github/babel/babel-library-boilerplate)
+[![Dependency Status](https://david-dm.org/babel/babel-library-boilerplate.svg)](https://david-dm.org/babel/babel-library-boilerplate)
+[![devDependency Status](https://david-dm.org/babel/babel-library-boilerplate/dev-status.svg)](https://david-dm.org/babel/babel-library-boilerplate#info=devDependencies)
 
 Author libraries in ES6 for Node and the browser.
 
@@ -20,7 +20,7 @@ Update the metadata about the project, including the name in the `LICENSE`
 and the `package.json` information.
 
 Write your code in `src`. The primary file is `index.js` ([although the filename
-can be changed](https://github.com/6to5/6to5-library-boilerplate#i-want-to-change-the-primary-source-file)).
+can be changed](https://github.com/babel/babel-library-boilerplate#i-want-to-change-the-primary-source-file)).
 
 Run `gulp build` to compile the source into a distributable format.
 
@@ -37,7 +37,7 @@ Put your unit tests in `test/unit`. The `gulp` command runs the tests.
 
 ### Browser Tests
 
-The [browser spec runner](https://github.com/6to5/6to5-library-boilerplate/blob/master/test/runner.html)
+The [browser spec runner](https://github.com/babel/babel-library-boilerplate/blob/master/test/runner.html)
 can be opened in a browser to run your tests. For it to work, you must first run `gulp test-browser`. This
 will set up a watch task that will automatically refresh the tests when your scripts, or the tests, change.
 
@@ -53,7 +53,7 @@ Either of these items on the list can simply be ignored if you're uninterested i
 out entirely from the boilerplate and not worry about it. To do that, update the relevant Gulp tasks and the Travis
 build.
 
-If you'd like to set up Code Climate for your project, follow [the steps here](https://github.com/6to5/6to5-library-boilerplate/wiki/Code-Climate).
+If you'd like to set up Code Climate for your project, follow [the steps here](https://github.com/babel/babel-library-boilerplate/wiki/Code-Climate).
 
 ### Linting
 
@@ -82,12 +82,12 @@ If you're building a full-scale webapp, you will likely need many more changes t
 #### What's the browser compatibility?
 
 As a rule of thumb, this transpiler works best in IE9+. You can support IE8 by limiting yourself
-to a subset of ES6 features. The [6to5 caveats page](http://6to5.org/docs/usage/caveats/) does an
+to a subset of ES6 features. The [Babel caveats page](http://babeljs.io/docs/usage/caveats/) does an
 excellent job at explaining the nitty gritty details of supporting legacy browsers.
 
 #### Are there examples?
 
-Quite a few! Check them out on [the wiki](https://github.com/6to5/6to5-library-boilerplate/wiki/Examples).
+Quite a few! Check them out on [the wiki](https://github.com/babel/babel-library-boilerplate/wiki/Examples).
 
 #### Is there a Yeoman generator?
 
@@ -104,7 +104,7 @@ The primary source file for the library is `src/index.js`. Only the files that t
 file imports will be included in the final build. To change the name of this entry file:
 
 1. Rename the file
-2. Update the value of `entryFileName` in `package.json` under `to5BoilerplateOptions`
+2. Update the value of `entryFileName` in `package.json` under `babelBoilerplateOptions`
 
 #### I want to change the exported file name
 
@@ -120,7 +120,7 @@ file imports will be included in the final build. To change the name of this ent
 these steps:
 
 1. Ensure that the variable you're exporting exists in your scripts
-2. Update the value of `exportVarName` in `package.json` under `to5BoilerplateOptions`
+2. Update the value of `exportVarName` in `package.json` under `babelBoilerplateOptions`
 3. Update the globals array in the `test/.jshintrc` file
 4. Check that the unit tests have been updated to reference the new value
 
@@ -137,8 +137,8 @@ In the simplest case, you just need to install the module and use it in your scr
 If you want to access the module itself in your unit test files, you will need to set up the
 test environment to support the module. To do this:
 
-1. Load the module in the [test setup file](https://github.com/6to5/6to5-library-boilerplate/blob/master/test/setup/setup.js).
+1. Load the module in the [test setup file](https://github.com/babel/babel-library-boilerplate/blob/master/test/setup/setup.js).
   Attach any exported variables to global object if you'll be using them in your tests.
 2. Update both `.jshintrc` files to include any new global variable that you have added
 3. Add those same global variables to the `mochaGlobals` array in `package.json` under
-  `to5BoilerplateOptions`
+  `babelBoilerplateOptions`

--- a/gulpfile.js
+++ b/gulpfile.js
@@ -1,13 +1,11 @@
 var gulp = require('gulp');
-var $ = require('gulp-load-plugins')({
-  replaceString: /^gulp(-|\.)([0-9]+)?/
-});
+var $ = require('gulp-load-plugins')();
 const fs = require('fs');
 const del = require('del');
 const glob = require('glob');
 const path = require('path');
 const mkdirp = require('mkdirp');
-const to5ify = require('6to5ify');
+const babelify = require('babelify');
 const isparta = require('isparta');
 const esperanto = require('esperanto');
 const browserify = require('browserify');
@@ -15,7 +13,7 @@ const runSequence = require('run-sequence');
 const source = require('vinyl-source-stream');
 
 const manifest = require('./package.json');
-const config = manifest.to5BoilerplateOptions;
+const config = manifest.babelBoilerplateOptions;
 const mainFile = manifest.main;
 const destinationFolder = path.dirname(mainFile);
 const exportFileName = path.basename(mainFile, path.extname(mainFile));
@@ -86,7 +84,7 @@ gulp.task('build', ['lint-src', 'clean'], function(done) {
     $.file(exportFileName + '.js', res.code, { src: true })
       .pipe($.plumber())
       .pipe($.sourcemaps.init({ loadMaps: true }))
-      .pipe($.to5({ blacklist: ['useStrict'] }))
+      .pipe($.babel({ blacklist: ['useStrict'] }))
       .pipe($.sourcemaps.write('./', {addComment: false}))
       .pipe(gulp.dest(destinationFolder))
       .pipe($.filter(['*', '!**/*.js.map']))
@@ -105,7 +103,7 @@ gulp.task('browserify', function() {
   var testFiles = glob.sync('./test/unit/**/*');
   var allFiles = ['./test/setup/browserify.js'].concat(testFiles);
   var bundler = browserify(allFiles);
-  bundler.transform(to5ify.configure({
+  bundler.transform(babelify.configure({
     sourceMapRelative: __dirname + '/src',
     blacklist: ['useStrict']
   }));
@@ -122,7 +120,7 @@ gulp.task('browserify', function() {
 });
 
 gulp.task('coverage', function(done) {
-  require('6to5/register')({ modules: 'common' });
+  require('babel/register')({ modules: 'common' });
   gulp.src(['src/*.js'])
     .pipe($.plumber())
     .pipe($.istanbul({ instrumenter: isparta.Instrumenter }))
@@ -142,7 +140,7 @@ function test() {
 
 // Lint and run our tests
 gulp.task('test', ['lint-src', 'lint-test'], function() {
-  require('6to5/register')({ modules: 'common' });
+  require('babel/register')({ modules: 'common' });
   return test();
 });
 

--- a/package.json
+++ b/package.json
@@ -1,5 +1,5 @@
 {
-  "name": "6to5-library-boilerplate",
+  "name": "babel-library-boilerplate",
   "version": "2.1.0",
   "description": "Author libraries in ES6 for Node and the browser.",
   "main": "dist/library-dist.js",
@@ -11,7 +11,7 @@
   },
   "repository": {
     "type": "git",
-    "url": "https://github.com/6to5/6to5-library-boilerplate.git"
+    "url": "https://github.com/babel/babel-library-boilerplate.git"
   },
   "keywords": [
     "boilerplate",
@@ -20,24 +20,25 @@
     "starter",
     "kit",
     "transpile",
-    "6to5"
+    "6to5",
+    "babel"
   ],
   "author": "Jmeas",
   "license": "MIT",
   "bugs": {
-    "url": "https://github.com/6to5/6to5-library-boilerplate/issues"
+    "url": "https://github.com/babel/babel-library-boilerplate/issues"
   },
-  "homepage": "https://github.com/6to5/6to5-library-boilerplate",
+  "homepage": "https://github.com/babel/babel-library-boilerplate",
   "devDependencies": {
-    "6to5": "^3.3.3",
-    "6to5ify": "^4.1.1",
+    "babel": "^4.3.0",
+    "babelify": "^5.0.3",
     "browserify": "^8.1.1",
     "chai": "^1.10.0",
     "del": "^1.1.1",
     "esperanto": "^0.6.7",
     "glob": "^4.3.5",
     "gulp": "^3.8.10",
-    "gulp-6to5": "^3.0.0",
+    "gulp-babel": "^4.0.0",
     "gulp-file": "^0.2.0",
     "gulp-filter": "^2.0.0",
     "gulp-istanbul": "^0.6.0",
@@ -60,7 +61,7 @@
     "sinon-chai": "^2.6.0",
     "vinyl-source-stream": "^1.0.0"
   },
-  "to5BoilerplateOptions": {
+  "babelBoilerplateOptions": {
     "entryFileName": "index",
     "exportVarName": "MyLibrary",
     "mochaGlobals": [

--- a/test/runner.html
+++ b/test/runner.html
@@ -5,8 +5,8 @@
   <title>Tests</title>
   <link rel='stylesheet' href='../node_modules/mocha/mocha.css' />
 
-  <!-- Polyfill (required by 6to5) -->
-  <script src='../node_modules/6to5/browser-polyfill.js'></script>
+  <!-- Polyfill (required by Babel) -->
+  <script src='../node_modules/babel/browser-polyfill.js'></script>
 
   <!-- Testing libraries -->
   <script src='../node_modules/mocha/mocha.js'></script>

--- a/test/setup/browserify.js
+++ b/test/setup/browserify.js
@@ -1,4 +1,4 @@
-var config = require('../../package.json').to5BoilerplateOptions;
+var config = require('../../package.json').babelBoilerplateOptions;
 
 global.mocha.setup('bdd');
 global.onload = function() {

--- a/test/setup/node.js
+++ b/test/setup/node.js
@@ -2,5 +2,5 @@ global.chai = require('chai');
 global.sinon = require('sinon');
 global.chai.use(require('sinon-chai'));
 
-require("6to5/register");
+require('babel/register');
 require('./setup')();


### PR DESCRIPTION
Also update dependencies to use Babel name. Resolves #114